### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2
+
+COPY ./requirements.txt /usr/src/app/
+WORKDIR /usr/src/app/
+RUN pip install -r requirements.txt
+
+COPY . /usr/src/app/
+
+ENTRYPOINT [ "./upnp_da_check.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+enum
+netifaces


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official Python:2 image, latest tag. More info at https://hub.docker.com/_/python/

Also added a `requirements.txt` file for convenience, which also enables using Docker build image layering cache to speed up image builds when repeating.
Just install dependencies, adding files, setting working dir and setting `ENTRYPOINT`.

Build:

```
$ docker build -t upnp_da_check .
```

Run:

```
$ docker run --rm -it --net=host upnp_da_check
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it --net=host pataquets/upnp_da_check
```

Using `--rm` makes the container not go background and it to be deleted after stop.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.